### PR TITLE
Manually added classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,6 @@
             <version>7.3.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.bingorufus</groupId>
-            <artifactId>command-creator</artifactId>
-            <version>1.2.2</version>
-        </dependency>
     </dependencies>
     <build>
         <!-- By default ${revision} is ${build.version}-SNAPSHOT -->

--- a/src/main/java/me/latestion/hoh/commandmanager/AbstractCommand.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/AbstractCommand.java
@@ -1,0 +1,80 @@
+package me.latestion.hoh.commandmanager;
+
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public abstract class AbstractCommand {
+
+    private final String commandName;
+    private final CommandExecutor commandHandler;
+    private final TabCompleter tabHandler;
+    private final Permission permission;
+    private final String permissionMessage;
+    private final Set<AbstractCommand> subCommands;
+    private final HashMap<String, Boolean> aliases;
+    private String usageMessage;
+
+    AbstractCommand(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases) {
+        this.commandName = commandName;
+        this.commandHandler = commandHandler;
+        this.tabHandler = tabHandler;
+        this.permission = permission;
+        this.permissionMessage = permissionMessage;
+        this.usageMessage = usageMessage;
+        this.subCommands = subCommands;
+        this.aliases = aliases;
+        this.aliases.put(commandName, true);
+        assignHead(this);
+    }
+
+    public String getCommandName() {
+        return commandName;
+    }
+
+    public CommandExecutor getCommandHandler() {
+        return commandHandler;
+    }
+
+    public TabCompleter getTabHandler() {
+        return tabHandler;
+    }
+
+    public Permission getPermission() {
+        return permission;
+    }
+
+    public String getPermissionMessage() {
+        return permissionMessage;
+    }
+
+    public String getUsageMessage() {
+        return usageMessage;
+    }
+
+    public void setUsageMessage(String usageMessage) {
+        this.usageMessage = usageMessage;
+    }
+
+    public Set<AbstractCommand> getSubCommands() {
+        return subCommands;
+    }
+
+    public HashMap<String, Boolean> getAliases() {
+        return new HashMap<String, Boolean>() {{
+            putAll(aliases);
+        }};
+    }
+
+    private void assignHead(AbstractCommand command) {
+        command.getSubCommands().forEach(cmd -> {
+            if (cmd instanceof SubCommand) {
+                ((SubCommand) cmd).setParent(command);
+            }
+            assignHead(cmd);
+        });
+    }
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/CommandCaller.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/CommandCaller.java
@@ -1,0 +1,93 @@
+package me.latestion.hoh.commandmanager;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+class CommandCaller implements CommandExecutor {
+    private final HeadCommand headCommand;
+
+    CommandCaller(HeadCommand headCommand) {
+        this.headCommand = headCommand;
+    }
+
+    @Override
+    public boolean onCommand(@Nonnull CommandSender sender, Command command, @Nonnull String label, @Nonnull String[] args) {
+        if (!command.getName().equalsIgnoreCase(headCommand.getCommandName())) {
+            return true;
+        }
+        AbstractCommand applicableCommand = getSubCommand(headCommand, args);
+        if (applicableCommand == null) applicableCommand = getLastCommand(headCommand, args);
+
+
+        if (applicableCommand.getPermission() != null && !sender.hasPermission(applicableCommand.getPermission())) {
+            sender.sendMessage(applicableCommand.getPermissionMessage());
+            return true;
+        }
+        String[] relevantArgs = getRelevantArgs(args, applicableCommand);
+        if (applicableCommand.getCommandHandler() != null) {
+            if (!applicableCommand.getCommandHandler().onCommand(sender, command, label, relevantArgs)) {
+                sender.sendMessage(applicableCommand.getUsageMessage());
+            }
+            return true;
+
+        }
+        if (getHelpCommand() != null) {
+            getHelpCommand().getCommandHandler().onCommand(sender, command, label, relevantArgs);
+            return true;
+        }
+        sender.sendMessage(headCommand.getUsageMessage());
+
+        return true;
+    }
+
+    private AbstractCommand getSubCommand(AbstractCommand command, String[] args) {
+        if (command.getSubCommands().size() == 0 || args.length == 0) return command;
+        for (AbstractCommand sub : command.getSubCommands()) {
+            for (String alias : sub.getAliases().keySet()) {
+                if (alias.equalsIgnoreCase(args[0])) {
+                    return getSubCommand(sub, removeFirstItem(args));
+                }
+            }
+        }
+        return null;
+    }
+
+    private String[] removeFirstItem(String[] args) {
+        ArrayList<String> out = new ArrayList<>(Arrays.asList(args));
+        out.remove(0);
+        return out.toArray(new String[0]);
+    }
+
+    private AbstractCommand getLastCommand(AbstractCommand command, String[] args) {
+        if (command.getSubCommands().size() == 0 || args.length == 0) return command;
+        for (AbstractCommand commandSubCommand : command.getSubCommands()) {
+            for (String commandName : commandSubCommand.getAliases().keySet()) {
+                if (commandName.equalsIgnoreCase(args[0])) {
+                    return getLastCommand(commandSubCommand, removeFirstItem(args));
+                }
+            }
+        }
+        return command;
+    }
+
+    private AbstractCommand getHelpCommand() {
+        return headCommand.getSubCommands().stream().filter(subCommand1 -> subCommand1.getCommandName().equalsIgnoreCase("help")).findFirst().orElse(null);
+    }
+
+    private String[] getRelevantArgs(String[] args, AbstractCommand command) {
+        if (args.length == 0) return args;
+        String[] out = args;
+        while (command instanceof SubCommand) {
+            SubCommand sub = (SubCommand) command;
+            out = removeFirstItem(out);
+            if (!sub.hasParent()) break;
+            command = sub.getParent();
+        }
+        return out;
+    }
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/CommandInitializer.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/CommandInitializer.java
@@ -1,8 +1,9 @@
 package me.latestion.hoh.commandmanager;
 
-import com.bingorufus.commandcreator.builders.CommandBuilder;
-import com.bingorufus.commandcreator.builders.SubCommandBuilder;
+
 import me.latestion.hoh.HideOrHunt;
+import me.latestion.hoh.commandmanager.builders.CommandBuilder;
+import me.latestion.hoh.commandmanager.builders.SubCommandBuilder;
 import me.latestion.hoh.data.flat.FlatHOHGame;
 import me.latestion.hoh.game.GameState;
 import me.latestion.hoh.game.HOHGame;
@@ -176,7 +177,7 @@ public class CommandInitializer {
 
         if (plugin.support != null) {
             builder.addSubCommand(new SubCommandBuilder("queue").setCommandHandler((sender, command, label, args) -> {
-                if (args.length == 1) {
+                if (args.length == 0) {
                     if (sender instanceof Player) {
                         plugin.support.queuePlayer((Player) sender);
                     } else {
@@ -185,9 +186,9 @@ public class CommandInitializer {
                     }
                     return true;
                 }
-                if (args.length == 2) {
+                if (args.length == 1) {
                     try {
-                        Player p = Bukkit.getPlayerExact(args[1]);
+                        Player p = Bukkit.getPlayerExact(args[0]);
                         if (p == null || !p.isValid()) {
                             sender.sendMessage(messageManager.getMessage("invalid-player"));
                             return true;

--- a/src/main/java/me/latestion/hoh/commandmanager/HeadCommand.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/HeadCommand.java
@@ -1,0 +1,50 @@
+package me.latestion.hoh.commandmanager;
+
+import me.latestion.hoh.commandmanager.builders.CommandBuilder;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.PluginCommand;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * The main parent for all commands
+ *
+ * @see CommandBuilder
+ */
+
+public class HeadCommand extends AbstractCommand {
+    private boolean isRegistered = false;
+
+    /**
+     * It is highly recommended to use the command builder
+     *
+     * @see CommandBuilder
+     */
+    public HeadCommand(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases) {
+        super(commandName, commandHandler, tabHandler, permission, permissionMessage, usageMessage, subCommands, aliases);
+    }
+
+    /**
+     * Register a command, this will create a CommandExecutor and TabCompleter for all subcommands
+     *
+     * @param plugin your main class
+     */
+    public void register(JavaPlugin plugin) {
+        if (plugin == null) throw new IllegalArgumentException("plugin cannot be null");
+        if (isRegistered) throw new RuntimeException("This command has already been registered");
+        PluginCommand cmd = plugin.getCommand(getCommandName());
+        if (cmd == null)
+            throw new RuntimeException("A command with the name of \"{c}\" has not been registered in the plugin.yml".replace("{c}", getCommandName()));
+        cmd.setExecutor(new CommandCaller(this));
+        cmd.setTabCompleter(new me.latestion.hoh.commandmanager.TabCompleter(this));
+        isRegistered = true;
+    }
+
+    public boolean isRegistered() {
+        return isRegistered;
+    }
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/SubCommand.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/SubCommand.java
@@ -1,0 +1,35 @@
+package me.latestion.hoh.commandmanager;
+
+
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Set;
+
+public class SubCommand extends AbstractCommand {
+    private AbstractCommand parent;
+
+    public SubCommand(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases) {
+        super(commandName, commandHandler, tabHandler, permission, permissionMessage, usageMessage, subCommands, aliases);
+    }
+
+    public @Nullable
+    AbstractCommand getParent() {
+        return parent;
+    }
+
+    public void setParent(@Nonnull AbstractCommand parent) {
+        if (this.parent != null) this.parent.getSubCommands().remove(this);
+        parent.getSubCommands().add(this);
+        this.parent = parent;
+    }
+
+    public boolean hasParent() {
+        return parent != null;
+    }
+
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/TabCompleter.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/TabCompleter.java
@@ -1,0 +1,85 @@
+package me.latestion.hoh.commandmanager;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class TabCompleter implements org.bukkit.command.TabCompleter {
+    private final HeadCommand headCommand;
+
+    TabCompleter(HeadCommand headCommand) {
+        this.headCommand = headCommand;
+    }
+
+    @Override
+    public List<String> onTabComplete(@Nonnull CommandSender sender, @Nonnull Command command, @Nonnull String label, @Nonnull String[] args) {
+        ArrayList<String> out = new ArrayList<>();
+        ArrayList<String> possible = new ArrayList<>();
+        AbstractCommand writtenCommand = getSubCommand(headCommand, args);
+        if (writtenCommand == null) return out;
+        if (writtenCommand.getPermission() != null && !sender.hasPermission(writtenCommand.getPermission())) return out;
+
+        String[] relevantArgs = getRelevantArgs(args, writtenCommand);
+        if (writtenCommand.getTabHandler() != null) {
+            possible.addAll(writtenCommand.getTabHandler().onTabComplete(sender, command, label, relevantArgs));
+        }
+
+        writtenCommand.getSubCommands().forEach(sub -> {
+            if (sub.getPermission() != null && !sender.hasPermission(sub.getPermission())) return;
+            sub.getAliases().forEach((alias, tab) -> {
+                if (tab) possible.add(alias);
+            });
+        });
+        possible.forEach(possibleTab -> {
+            if (relevantArgs != null && !startsWith(relevantArgs, splitToArg(possibleTab))) return;
+            out.add(possibleTab);
+        });
+        return out;
+    }
+
+    private AbstractCommand getSubCommand(AbstractCommand command, String[] args) {
+        if (command.getSubCommands().size() == 0 || args.length == 0) return command;
+        for (AbstractCommand commandSubCommand : command.getSubCommands()) {
+            for (String commandName : commandSubCommand.getAliases().keySet()) {
+                if (commandName.equalsIgnoreCase(args[0]))
+                    return getSubCommand(commandSubCommand, removeFirstItem(args));
+                if (commandName.toUpperCase().startsWith(args[0].toUpperCase()) && args.length == 1) return command;
+            }
+        }
+        return null;
+    }
+
+    private String[] getRelevantArgs(String[] args, AbstractCommand command) {
+        if (args.length == 0) return args;
+        String[] out = args;
+        while (command instanceof SubCommand) {
+            SubCommand sub = (SubCommand) command;
+            out = removeFirstItem(out);
+            if (!sub.hasParent()) break;
+            command = sub.getParent();
+        }
+        return out;
+    }
+
+    private String[] removeFirstItem(String[] args) {
+        ArrayList<String> out = new ArrayList<>(Arrays.asList(args));
+        out.remove(0);
+        return out.toArray(new String[0]);
+    }
+
+    private String[] splitToArg(String argument) {
+        return argument.split(" ");
+    }
+
+    private boolean startsWith(String[] args, String[] suggestion) {
+        if (args.length > suggestion.length) return false;
+        if (args.length == 0) return true;
+        if (suggestion[0].equals(args[0])) return startsWith(removeFirstItem(args), removeFirstItem(suggestion));
+
+        return suggestion[0].startsWith(args[0]);
+    }
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/builders/AbstractCommandBuilder.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/builders/AbstractCommandBuilder.java
@@ -1,0 +1,180 @@
+package me.latestion.hoh.commandmanager.builders;
+
+
+import javafx.util.Builder;
+import me.latestion.hoh.commandmanager.AbstractCommand;
+import me.latestion.hoh.commandmanager.HeadCommand;
+import me.latestion.hoh.commandmanager.SubCommand;
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class AbstractCommandBuilder<T extends AbstractCommand> implements Builder<T> {
+    private final Set<AbstractCommand> subcommands = new HashSet<>();
+    private final String commandName;
+    private final HashMap<String, Boolean> aliases = new HashMap<>();
+    private String permissionName;
+    private PermissionDefault permissionLevel;
+    private boolean createPermission = true;
+    private Permission permission;
+    private String usageMessage;
+    private String permissionMessage = "§cYou do not permission to do that!";
+    private CommandExecutor commandHandler;
+    private TabCompleter tabHandler;
+
+    /**
+     * Create a new command
+     *
+     * @param commandName Only one word is required, and not the full path
+     */
+    AbstractCommandBuilder(String commandName) {
+        this.commandName = commandName;
+    }
+
+    /**
+     * Set the permission for the command, players who do not have permission to run the command will not be able
+     * to tab complete the command. Upon running the command, players without permission will be sent the permission message {@link AbstractCommandBuilder#setPermissionMessage(String)}
+     *
+     * @param permission      Full permission in the form of a string
+     * @param permissionLevel The default permission level
+     * @return the builder
+     * @see AbstractCommandBuilder#setPermissionMessage(String)
+     * @see AbstractCommandBuilder#setPermission(Permission)
+     */
+    public AbstractCommandBuilder<T> setPermission(final String permission, final PermissionDefault permissionLevel) {
+        this.permissionName = permission;
+        this.permissionLevel = permissionLevel;
+        createPermission = true;
+        return this;
+    }
+
+    /**
+     * Set the permission for the command, players who do not have permission to run the command will not be able
+     * to tab complete the command. Upon running the command, players without permission will be sent the permission message {@link AbstractCommandBuilder#setPermissionMessage(String)}
+     * <p>
+     * If the permission has not already been registered it will be registered automatically.
+     *
+     * @param permission Permission registered or unregistered
+     * @return the builder
+     * @see AbstractCommandBuilder#setPermissionMessage(String)
+     * @see AbstractCommandBuilder#setPermission(String, PermissionDefault)
+     */
+    public AbstractCommandBuilder<T> setPermission(final Permission permission) {
+        this.permission = permission;
+        createPermission = false;
+        return this;
+    }
+
+    /**
+     * Upon running the command, players without permission will be sent this message.
+     * <p>
+     * By default the permission message will be "§cYou do not permission to do that!"
+     *
+     * @param permissionMessage the message that will be sent
+     * @return the builder
+     * The permission can be set with {@link AbstractCommandBuilder#setPermission(String, PermissionDefault)} or {@link AbstractCommandBuilder#setPermission(Permission)}
+     */
+    public AbstractCommandBuilder<T> setPermissionMessage(final String permissionMessage) {
+        this.permissionMessage = permissionMessage;
+        return this;
+    }
+
+    /**
+     * The usage message will be sent to the player if the command handler returns false.
+     * If this is not set, a  usage message will automatically be generated based upon the command's parents
+     *
+     * @param usageMessage the message that will be sent
+     * @return the builder
+     */
+
+    public AbstractCommandBuilder<T> setUsageMessage(final String usageMessage) {
+        this.usageMessage = usageMessage;
+        return this;
+    }
+
+
+    /**
+     * Add command aliases. Note: the command name is automatically added upon building {@link AbstractCommandBuilder#build()}
+     *
+     * @param alias    The name of the alias
+     * @param isTabbed Setting this to true will allow the command to be tabbed in chat, otherwise it will not show up
+     *                 Subcommands will still show up after writing the alias if this is set to false
+     * @return the builder
+     */
+    public AbstractCommandBuilder<T> addAlias(String alias, boolean isTabbed) {
+        aliases.put(alias, isTabbed);
+        return this;
+    }
+
+    /**
+     * Add a subcommand to the command executor and to the tab completer
+     * It is highly recommended to use {@link SubCommandBuilder}
+     *
+     * @param subCommand the added subcommand
+     * @return the builder
+     */
+    public AbstractCommandBuilder<T> addSubCommand(SubCommand subCommand) {
+        this.subcommands.add(subCommand);
+        return this;
+    }
+
+    /**
+     * Set the command executor.  This method will only be called when the player has typed this AbstractCommand, meaning
+     * that you do not need to check arguments. Returning false in the command handler will send the command sender the
+     * usage message {@link AbstractCommandBuilder#setUsageMessage(String)}
+     *
+     * @param commandHandler the command executor
+     * @return the builder
+     */
+    public AbstractCommandBuilder<T> setCommandHandler(CommandExecutor commandHandler) {
+        this.commandHandler = commandHandler;
+        return this;
+    }
+
+    /**
+     * Set the tab handler. This method will only be called when the player has typed this AbstractCommand, meaning
+     * that you do not need to check arguments. Items in the returned string list will automatically be removed if the
+     * arguments do not start with the arguments
+     *
+     * @param tabHandler the tab handler
+     * @return the builder
+     */
+    public AbstractCommandBuilder<T> setTabHandler(TabCompleter tabHandler) {
+        this.tabHandler = tabHandler;
+        return this;
+    }
+
+    /**
+     * Compiles the command. When making a parent command, the command handler and tab handler will not be ran unless the
+     * command is registered {@link HeadCommand#register(JavaPlugin)}
+     *
+     * @return the built command
+     */
+    @Override
+    public T build() {
+        if (createPermission && permissionName != null) {
+            if (Bukkit.getPluginManager().getPermission(permissionName) != null) {
+                permission = Bukkit.getPluginManager().getPermission(permissionName);
+                assert permission != null;
+            } else {
+                permission = new Permission(permissionName);
+                permission.setDefault(permissionLevel);
+                Bukkit.getServer().getPluginManager().addPermission(permission);
+            }
+
+        } else if (permission != null && !Bukkit.getServer().getPluginManager().getPermissions().contains(permission)) {
+            Bukkit.getServer().getPluginManager().addPermission(permission);
+        }
+
+        return build(commandName, commandHandler, tabHandler, permission, permissionMessage, usageMessage, subcommands, aliases);
+    }
+
+    protected abstract T build(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases);
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/builders/CommandBuilder.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/builders/CommandBuilder.java
@@ -1,0 +1,105 @@
+package me.latestion.hoh.commandmanager.builders;
+
+import me.latestion.hoh.commandmanager.AbstractCommand;
+import me.latestion.hoh.commandmanager.HeadCommand;
+import me.latestion.hoh.commandmanager.SubCommand;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Set;
+
+/**
+ * @author BingoRufus
+ * @version 1.2
+ */
+public class CommandBuilder extends AbstractCommandBuilder<HeadCommand> {
+    private boolean generateHelpMessages = true;
+
+    /**
+     * Create a {@link HeadCommand}
+     *
+     * @param command The name of the command, this should only be one word
+     * @see HeadCommand#register(JavaPlugin)
+     * After building, HeadCommands will do nothing unless they are registered
+     */
+    public CommandBuilder(String command) {
+        super(command);
+    }
+
+    @Override
+    protected HeadCommand build(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases) {
+        HeadCommand cmd = new HeadCommand(commandName, commandHandler, tabHandler, permission, permissionMessage, usageMessage, subCommands, aliases);
+        String generatedUsage = generateUsageMessage(cmd, new StringBuilder());
+        if (generateHelpMessages && cmd.getSubCommands().stream().noneMatch(sub -> sub.getCommandName().equalsIgnoreCase("help"))) {
+            String usage = generatedUsage + "\n/" + commandName + " help";
+            SubCommand help = new SubCommandBuilder("help").setCommandHandler(((commandSender, command, s, strings) -> {
+                commandSender.sendMessage(usage);
+                return true;
+            })).build();
+            cmd.getSubCommands().add(help);
+
+        }
+
+        return cmd;
+    }
+
+    /**
+     * By default, a subcommand called '/<command> help' help will be generated which when ran will send the player
+     * a list of all of commands' usage messages. This can be overwrote by creating your own help sub command or setting
+     * this to false
+     *
+     * @param generateHelpMessage enable / disable automatically making the help command
+     */
+
+    public void setGenerateHelpMessage(boolean generateHelpMessage) {
+        this.generateHelpMessages = generateHelpMessage;
+    }
+
+    private String generateUsageMessage(AbstractCommand cmd, final StringBuilder message) {
+        if (message.length() != 0) message.append("\n");
+
+        String usage = getUsage(cmd);
+        if (cmd.getUsageMessage() == null) {
+            cmd.setUsageMessage(usage);
+        }
+        message.append(usage);
+        cmd.getSubCommands().forEach(subcommands -> generateUsageMessage(subcommands, message));
+
+        return message.toString();
+    }
+
+    private String getUsage(AbstractCommand end) {
+        if (end.getUsageMessage() != null) return end.getUsageMessage(); // Use already existing usage message
+
+        StringBuilder message = new StringBuilder("/");
+        for (AbstractCommand cmd : getPath(end)) { // Create a path like [head, sub, sub-sub]
+            if (message.length() != 1) message.append(" ");
+            message.append(cmd.getCommandName());
+        }
+        return message.toString();
+    }
+
+    private AbstractCommand[] getPath(AbstractCommand end) {
+        ArrayList<AbstractCommand> out = new ArrayList<>();
+        AbstractCommand edit = end;
+        while (edit != null) {
+            out.add(0, edit);
+            if (edit instanceof SubCommand) {
+                SubCommand sub = (SubCommand) edit;
+                if (sub.hasParent()) {
+                    edit = sub.getParent();
+                    continue;
+                }
+            }
+            break;
+        }
+        return out.toArray(new AbstractCommand[0]);
+
+    }
+
+
+}

--- a/src/main/java/me/latestion/hoh/commandmanager/builders/SubCommandBuilder.java
+++ b/src/main/java/me/latestion/hoh/commandmanager/builders/SubCommandBuilder.java
@@ -1,0 +1,29 @@
+package me.latestion.hoh.commandmanager.builders;
+
+
+import me.latestion.hoh.commandmanager.AbstractCommand;
+import me.latestion.hoh.commandmanager.SubCommand;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.permissions.Permission;
+
+import java.util.HashMap;
+import java.util.Set;
+
+public class SubCommandBuilder extends AbstractCommandBuilder<SubCommand> {
+
+    /**
+     * Crate a {@link SubCommand}. Subcommands parents / grandparents must eventually lead to a HeadCommand,
+     * to create a HeadCommand see {@link CommandBuilder}
+     *
+     * @param commandName the name of the command, this should only be one word
+     */
+    public SubCommandBuilder(String commandName) {
+        super(commandName);
+    }
+
+    @Override
+    protected SubCommand build(String commandName, CommandExecutor commandHandler, TabCompleter tabHandler, Permission permission, String permissionMessage, String usageMessage, Set<AbstractCommand> subCommands, HashMap<String, Boolean> aliases) {
+        return new SubCommand(commandName, commandHandler, tabHandler, permission, permissionMessage, usageMessage, subCommands, aliases);
+    }
+}


### PR DESCRIPTION
the command builder is now a maven repo, and it has been implemented as a dependency through the pom.xml

Only "relevant arguments" are passed through the command handler and tab handler, meaning that the arguments used to get to the command are removed.

"/command sub1 sub2 hello"
previously gave the command handler for "sub2" the arguments of "[sub1, sub2, hello]" now it received "[hello]"

Tab handlers won't repeat the same thing forever.